### PR TITLE
fix: fix large width for report images on web platform

### DIFF
--- a/change_analyzer/templates/Log_template.html
+++ b/change_analyzer/templates/Log_template.html
@@ -99,6 +99,10 @@ td, th {
 	padding: 0px 30px 0px 30px;
 	margin-left: -5px;
 }
+img {
+	max-width:100%;
+	height:auto;
+}
 </style>
 </head>
 <body>
@@ -134,8 +138,8 @@ td, th {
 				  </thead>
 				  <tbody>
 					<tr>
-					  <td><img src="{{ expected_image }}" alt=""></td>
-					  <td><img src="{{ actual_image }}" alt=""></td>
+					  	<td><img src="{{ expected_image }}" alt=""></td>
+					  	<td><img src="{{ actual_image }}" alt=""></td>
 					</tr>
 				  </tbody>
 			</table>


### PR DESCRIPTION
Fix images on win platform to be maximum as big as table cell