### PR TITLE
fix: fix enriched data for xml

### DIFF
--- a/change_analyzer/wrappers/sequence_recorder.py
+++ b/change_analyzer/wrappers/sequence_recorder.py
@@ -6,8 +6,9 @@ import time
 import json
 
 import gym as gym
+import selenium.webdriver.remote.webelement
 from gym import Wrapper
-from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.remote.webdriver import WebDriver, WebElement
 from lxml import html, etree
 
 from change_analyzer.spaces.actions.app_action import AppAction
@@ -54,8 +55,8 @@ class SequenceRecorder(Wrapper, TransparentWrapperMixin):
         return obs, reward, done, info
 
     @staticmethod
-    def _enrich_element(element_to_enrich, element_with_info):
-        h, w, x, y = element_with_info.rect.values()
+    def _enrich_element(element_to_enrich: html.HtmlElement, element_info: Dict):
+        h, w, x, y = element_info.values()
         element_to_enrich.set('x', str(x))
         element_to_enrich.set('y', str(y))
         element_to_enrich.set('height', str(h))
@@ -88,7 +89,7 @@ class SequenceRecorder(Wrapper, TransparentWrapperMixin):
         if 'xml' in page_source:
             for index, el in enumerate(all_elements_from_root[2::]):
                 # We bypass the first two elements of the list (/html and /html/body) - they have no map in the driver
-                self._enrich_element(el, all_elements_from_driver[index])
+                self._enrich_element(el, all_elements_from_driver[index].rect)
             return etree.tostring(root).decode("utf-8")
 
         for element in all_elements_from_root:

--- a/change_analyzer/wrappers/sequence_recorder.py
+++ b/change_analyzer/wrappers/sequence_recorder.py
@@ -61,11 +61,33 @@ class SequenceRecorder(Wrapper, TransparentWrapperMixin):
             - x, y coordinates
             - h, w dimensions
         """
-        # Get elements' by xpath from given page source
-        root = html.fromstring(info.page_source)
+        try:
+            page_source = info.page_source
+        except:
+            # Driver is no longer available - no page source to use
+            return ''
+
+        if 'xml' in page_source:
+            root = html.fromstring(page_source.encode("utf-16"))
+        else:
+            root = html.fromstring(info.page_source)
+
         tree = root.getroottree()
-        all_elements_by_xpath = root.xpath('//*')
-        for element in all_elements_by_xpath:
+
+        # Get elements' by xpath from given page source and
+        all_elements_from_root = root.xpath('//*')
+        all_elements_from_driver = info.find_elements_by_xpath("//*")
+
+        if 'xml' in page_source:
+            for index, el in enumerate(all_elements_from_root[2::]):
+                # We bypass the first two elements of the list (/html and /html/body) - they have no map in the driver
+                el.set('x', f"{all_elements_from_driver[index].location['x']}")
+                el.set('y', f"{all_elements_from_driver[index].location['y']}")
+                el.set('height', f"{all_elements_from_driver[index].size['height']}")
+                el.set('width', f"{all_elements_from_driver[index].size['width']}")
+            return etree.tostring(root).decode("utf-8")
+
+        for element in all_elements_from_root:
             element_xpath = tree.getpath(element)
             xpath_to_find = "./"
             if 'head' in element_xpath:


### PR DESCRIPTION
Data enrichment for xml is handled separately than html due to using html.fromstring to get the root