### PR TITLE
fix: fix diff validation

### DIFF
--- a/change_analyzer/sequences_diff.py
+++ b/change_analyzer/sequences_diff.py
@@ -197,7 +197,7 @@ class SequencesDiff:
             - script
         """
         ignored_diffs = ['ProcessId', 'RuntimeId', 'script']
-        return not any(ignored_diff in diff for ignored_diff in ignored_diffs)
+        return not any(ignored_diff.lower() in diff.lower() for ignored_diff in ignored_diffs)
 
     @staticmethod
     def _get_attribute_value_based_on_node(page_root: ET.Element, node: str, attribute: str) -> str:


### PR DESCRIPTION
Fix diff validation to have all strings lowercase, to avoid challenges when we have inconsistencies in different attributes
(ProcessID vs. processid)